### PR TITLE
Integers can have underscores

### DIFF
--- a/test/lang/parser_test.clj
+++ b/test/lang/parser_test.clj
@@ -52,13 +52,15 @@
                        :body           {:ast/term :atom :atom {:atom :integer :value "2"}}}
                       {:body {:atom {:atom :string :value "bar"}}}
                       {:body {:atom {:atom :boolean :value true}}}
-                      {:body {:atom {:atom :unit :value nil}}}]}
+                      {:body {:atom {:atom :unit :value nil}}}
+                      {:body {:atom {:atom :integer :value "55"}}}]}
        (run :parser
          (defmodule lang.parser-test.atom-definitions)
          (def foo 2)
          (def bar "bar")
          (def baz true)
-         (def quux nil)))))
+         (def quux nil)
+         "(def qaz 5_5)"))))
 
 (deftest parse-constructors
   (is (match?
@@ -158,22 +160,3 @@
            (true? :$ (-> T Bool)))
          (definstance (Veracious Bool)
            (true? [bool] bool))))))
-
-(deftest underscore_numbers
-  (is
-   (match?
-    {:ast/definition :module
-     :name {:reference :module, :name ["lang" "ints-module"]}
-     :skip-implicits nil
-     :imports nil
-     :definitions [{:ast/definition :constant
-                    :name {:reference :constant, :name "a"}
-                    :body {:ast/term :atom, :atom {:atom :integer, :value "11"}}}
-                   {:ast/definition :constant
-                    :name {:reference :constant :name "b"}
-                    :body {:ast/term :atom, :atom {:atom :integer, :value "11"}}}]}
-    (run :parser
-         "(defmodule lang.ints-module)"
-         "(def a 1_1)"
-         "(def b 11)"
-         "(def c 1_1.2_2)"))))

--- a/test/lang/parser_test.clj
+++ b/test/lang/parser_test.clj
@@ -158,3 +158,22 @@
            (true? :$ (-> T Bool)))
          (definstance (Veracious Bool)
            (true? [bool] bool))))))
+
+(deftest underscore_numbers
+  (is
+   (match?
+    {:ast/definition :module
+     :name {:reference :module, :name ["lang" "ints-module"]}
+     :skip-implicits nil
+     :imports nil
+     :definitions [{:ast/definition :constant
+                    :name {:reference :constant, :name "a"}
+                    :body {:ast/term :atom, :atom {:atom :integer, :value "11"}}}
+                   {:ast/definition :constant
+                    :name {:reference :constant :name "b"}
+                    :body {:ast/term :atom, :atom {:atom :integer, :value "11"}}}]}
+    (run :parser
+         "(defmodule lang.ints-module)"
+         "(def a 1_1)"
+         "(def b 11)"
+         "(def c 1_1.2_2)"))))

--- a/test/lang/test_prelude.clj
+++ b/test/lang/test_prelude.clj
@@ -6,9 +6,15 @@
 
 (defmacro run
   [phase & fs]
-  `(binding [*print-namespace-maps* false]
-       (-> (str/join " " (map pr-str (quote ~fs)))
-         (str/replace #"[,]" "")
-         (StringReader.)
-         (compiler/run :until ~phase))))
-
+  (binding [*print-namespace-maps* false]
+    (let [program
+          (mapv
+           (fn normalize-form [f]
+             (if (string? f)
+               f
+               (pr-str f)))
+           fs)]
+      `(-> (str/join " " ~program)
+           (str/replace #"[,]" "")
+           (StringReader.)
+           (compiler/run :until ~phase)))))


### PR DESCRIPTION
Keeping this minimal since it's the first PR, so you can say, "No, do this somewhere else".

Integers already seemed to accept underscores; AFAICT the test runner just couldn't parse them because they're not valid Clojure syntax. This slightly tweaks the runner to pass strings directly through before parsing, so we can pass Lang codestrings directly to the tests.

Codegen tests are failing, but they fail for me on master, so I...think I didn't do that?