### PR TITLE
Parse single expressions

### DIFF
--- a/src/lang/parser.clj
+++ b/src/lang/parser.clj
@@ -4,6 +4,12 @@
             [lang.parser.definition :as definition]
             [taoensso.timbre :as log]))
 
+(defn run-expr [s]
+  (let [{:keys [error ok value]} (kern/parse definition/expr s)]
+    (if ok 
+      value
+      (throw (ex-info "Failed to parse expr" error)))))
+
 (def ^:private file
   (kern/bind [forms (kern/many definition/expr)]
     (match forms
@@ -17,3 +23,6 @@
     (if (:ok result)
       (:value result)
       (throw (ex-info "Parsing error" (:error result))))))
+
+(comment
+  (run-expr "(def a 1)"))

--- a/test/lang/parser_test.clj
+++ b/test/lang/parser_test.clj
@@ -1,7 +1,20 @@
 (ns lang.parser-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is are]]
             [lang.test-prelude :refer :all]
+            [lang.parser :refer [run-expr]]
             matcher-combinators.test))
+
+(deftest parse-expressions  
+  (are [expr result]
+       (match? result (run-expr expr))
+    "(defmodule lang.parser-test.empty-module)"
+    {:ast/definition :module
+     :name           {:reference :module :name ["lang" "parser-test" "empty-module"]}     
+     :definitions    []}
+    "(def a 1)"
+    {:ast/definition :constant
+     :name {:reference :constant :name "a"}
+     :body {:ast/term :atom :atom {:atom :integer :value "1"}}}))
 
 (deftest empty-module
   (is (match?


### PR DESCRIPTION
Poked around a bit, first instinct is that step 1 to a REPL is parsing single expressions without module prelude, having to be a file, etc etc. Reasonable? Thought I'd get my foot in the door.